### PR TITLE
fix: prettier trailingComma:all

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,1 +1,0 @@
-trailingComma: es5 # "es5" was default until v3.0.0; now "all"

--- a/cdk/bin/app.ts
+++ b/cdk/bin/app.ts
@@ -12,7 +12,7 @@ const app = new cdk.App();
 new AppStacks(app, "Dev", {
   env: AppStacks.checkEnv(
     process.env.CDK_DEFAULT_ACCOUNT,
-    process.env.CDK_DEFAULT_REGION
+    process.env.CDK_DEFAULT_REGION,
   ),
   purpose: "Dev",
   appName: "LambdaPSExtensionTests",

--- a/cdk/lib/AppStacks.ts
+++ b/cdk/lib/AppStacks.ts
@@ -23,16 +23,16 @@ export class AppStacks extends Construct {
    */
   static checkEnv = (
     account: unknown,
-    region: unknown
+    region: unknown,
   ): { account: string; region: string } => {
     if (typeof account != "string" || !/\d{12}/.test(account))
       throw new Error(
-        `Provide an explicit AWS Account. ${account} is not a vaild Account.`
+        `Provide an explicit AWS Account. ${account} is not a vaild Account.`,
       );
 
     if (typeof region != "string" || !/[a-z]{2}-[a-z]{4,7}-\d/.test(region))
       throw new Error(
-        `Provide an explicit AWS Region. ${region} is not a vaild Region.`
+        `Provide an explicit AWS Region. ${region} is not a vaild Region.`,
       );
 
     return { account, region };
@@ -49,7 +49,7 @@ export class AppStacks extends Construct {
           "Retieve sample Parameters and Secrets from a Lambda using the P&S Extension.",
         env: props.env,
         terminationProtection: props.purpose === "Prod",
-      }
+      },
     );
 
     cdk.Tags.of(extensionStack).add("x:cdk:app-name", props.appName);

--- a/cdk/lib/LambdaPSExtension.ts
+++ b/cdk/lib/LambdaPSExtension.ts
@@ -51,13 +51,13 @@ export class LambdaPSExtension
 
     if (!layerArn) {
       cdk.Annotations.of(scope).addError(
-        "Cannot determine the Extension Layer ARN."
+        "Cannot determine the Extension Layer ARN.",
       );
     } else {
       this.#layer = lambda.LayerVersion.fromLayerVersionArn(
         scope,
         "ManagedLayer",
-        layerArn
+        layerArn,
       );
     }
   }
@@ -78,10 +78,10 @@ export class LambdaPSExtension
 
     return components.architecture
       ? regionArns.find(
-          (el) => el.architecture === components.architecture?.name
+          (el) => el.architecture === components.architecture?.name,
         )?.layerArn ?? null
       : regionArns.find(
-          (el) => el.architecture === cdk.aws_lambda.Architecture.X86_64.name
+          (el) => el.architecture === cdk.aws_lambda.Architecture.X86_64.name,
         )?.layerArn ?? null;
   }
 

--- a/cdk/lib/LambdaPSExtensionStack.ts
+++ b/cdk/lib/LambdaPSExtensionStack.ts
@@ -47,7 +47,7 @@ export class LambdaPSExtensionStack extends cdk.Stack {
   constructor(
     scope: Construct,
     id: string,
-    props: LambdaPSExtensionStackProps
+    props: LambdaPSExtensionStackProps,
   ) {
     super(scope, id, props);
 
@@ -67,7 +67,7 @@ export class LambdaPSExtensionStack extends cdk.Stack {
       {
         parameterName: `${paramPath}/dummy-string-list`,
         stringListValue: ["listval-0", "listval-1", "listval-2"],
-      }
+      },
     );
 
     // creates a SecureString Paramter
@@ -80,7 +80,7 @@ export class LambdaPSExtensionStack extends cdk.Stack {
     const stringSecret = new sm.Secret(this, "DummyStringSecret", {
       secretName: "dummy-string-secret",
       secretStringValue: cdk.SecretValue.unsafePlainText(
-        "an-insecure-string-secret-value"
+        "an-insecure-string-secret-value",
       ),
     });
 
@@ -137,17 +137,17 @@ export class LambdaPSExtensionStack extends cdk.Stack {
               resource: "parameter",
               resourceName: "aws/reference/secretsmanager/" + s,
               arnFormat: cdk.ArnFormat.SLASH_RESOURCE_NAME,
-            })
+            }),
           ),
         ],
-      })
+      }),
     );
 
     this.lambda.addToRolePolicy(
       new iam.PolicyStatement({
         actions: ["secretsmanager:GetSecretValue"],
         resources: [binarySecret.secretArn],
-      })
+      }),
     );
 
     this.lambda.node.addDependency(secureString);

--- a/cdk/lib/Secret/Secret.ts
+++ b/cdk/lib/Secret/Secret.ts
@@ -61,7 +61,7 @@ export class Secret extends Construct {
       (props.secretBinary && props.secretString)
     )
       throw new Error(
-        "Exactly one of secretString or secretBinary is required."
+        "Exactly one of secretString or secretBinary is required.",
       );
 
     this.secretName = props.secretName;

--- a/cdk/lib/Secret/handler.ts
+++ b/cdk/lib/Secret/handler.ts
@@ -23,7 +23,7 @@ type Event = Omit<CdkCustomResourceEvent, "ResourceProperties"> & {
  * [lifecycle events](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.custom_resources-readme.html#handling-lifecycle-events-onevent)
  */
 export const handler = async (
-  event: Event
+  event: Event,
 ): Promise<CdkCustomResourceResponse> => {
   try {
     const { secretName, secretString, secretBinary, description } =
@@ -40,7 +40,7 @@ export const handler = async (
         new DeleteSecretCommand({
           SecretId: secretName,
           ForceDeleteWithoutRecovery: true,
-        })
+        }),
       );
 
       return physId;
@@ -59,7 +59,7 @@ export const handler = async (
         new CreateSecretCommand({
           ...commonInput,
           Name: secretName,
-        })
+        }),
       );
 
       const suffix = " updatedVersion!";
@@ -75,7 +75,7 @@ export const handler = async (
               ])
             : undefined,
           SecretString: secretString ? secretString + suffix : undefined,
-        })
+        }),
       );
 
       return {
@@ -90,7 +90,7 @@ export const handler = async (
       new UpdateSecretCommand({
         ...commonInput,
         SecretId: secretName,
-      })
+      }),
     );
 
     return {

--- a/cdk/lib/SecureString/handler.ts
+++ b/cdk/lib/SecureString/handler.ts
@@ -23,7 +23,7 @@ type Event = Omit<CdkCustomResourceEvent, "ResourceProperties"> & {
  * [lifecycle events](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.custom_resources-readme.html#handling-lifecycle-events-onevent)
  */
 export const handler = async (
-  event: Event
+  event: Event,
 ): Promise<CdkCustomResourceResponse> => {
   try {
     const { parameterName, stringValue, keyId, dataType } =
@@ -37,7 +37,7 @@ export const handler = async (
       await client.send(
         new DeleteParameterCommand({
           Name: parameterName,
-        })
+        }),
       );
 
       return physId;
@@ -62,7 +62,7 @@ export const handler = async (
       new PutParameterCommand({
         ...putInput,
         Value: stringValue + " - " + new Date().toISOString(),
-      })
+      }),
     );
 
     await client.send(
@@ -70,7 +70,7 @@ export const handler = async (
         Name: parameterName,
         ParameterVersion: res.Version ? res.Version - 1 : undefined,
         Labels: ["Dev"],
-      })
+      }),
     );
 
     await client.send(
@@ -78,7 +78,7 @@ export const handler = async (
         Name: parameterName,
         ParameterVersion: res.Version,
         Labels: ["Prod"],
-      })
+      }),
     );
 
     return {

--- a/cdk/lib/funcTestCases.ts
+++ b/cdk/lib/funcTestCases.ts
@@ -127,7 +127,7 @@ export async function handler(): Promise<TestResponses> {
       description:
         "The stringSecretfromParameterStore method returns a Secret using the Parameter Store endpoint.",
       value: await client.stringSecretfromParameterStore(
-        cases.stringSecret.name
+        cases.stringSecret.name,
       ),
       response: await client.parameterResponse(cases.stringSecret.name, {
         withDecryption: true,
@@ -148,7 +148,7 @@ export async function handler(): Promise<TestResponses> {
         cases.binarySecret.name,
         {
           label: "AWSPREVIOUS",
-        }
+        },
       ),
       response: await client.parameterResponse(cases.binarySecret.name, {
         withDecryption: true,
@@ -236,7 +236,7 @@ export async function handler(): Promise<TestResponses> {
     return { result: "success", responses };
   } catch (err: unknown) {
     console.log(
-      err instanceof Error ? err.message : "An unknown error has occurred."
+      err instanceof Error ? err.message : "An unknown error has occurred.",
     );
 
     return { result: "failure", responses: { ...happy, ...unhappy } };

--- a/scripts/extensionArns.ts
+++ b/scripts/extensionArns.ts
@@ -13,7 +13,7 @@ import { ExtensionArn } from "../data/types";
   const requester = new HttpRequester();
 
   const res = await requester.get(
-    "https://docs.aws.amazon.com/systems-manager/latest/userguide/ps-integration-lambda-extensions.html"
+    "https://docs.aws.amazon.com/systems-manager/latest/userguide/ps-integration-lambda-extensions.html",
   );
 
   if (!res.text) throw new Error("No respoonse text!");
@@ -49,21 +49,21 @@ import { ExtensionArn } from "../data/types";
 
   Object.entries(arnSets).forEach(([k, v]) => {
     arns[k] = Array.from(v).sort(
-      (a, b) => b.architecture.localeCompare(a.architecture) // sort in descending order
+      (a, b) => b.architecture.localeCompare(a.architecture), // sort in descending order
     );
   });
 
   assert(
     Object.keys(arns).length >= 27,
-    "The number of regions with extension ARNs has not declined."
+    "The number of regions with extension ARNs has not declined.",
   );
   assert(
     Object.values(arns).flat(1).length >= 37,
-    "The number of Extension ARNs has not declined."
+    "The number of Extension ARNs has not declined.",
   );
 
   await fs.writeFile(
     path.join(__dirname, "../data/aws-layer-arns.json"),
-    JSON.stringify(arns, null, "  ") + "\n"
+    JSON.stringify(arns, null, "  ") + "\n",
   );
 })();

--- a/src/Client.test.ts
+++ b/src/Client.test.ts
@@ -16,14 +16,14 @@ describe("Client returns the expected mock requests.", () => {
   describe("Parameters", () => {
     test("String parameter value returns.", async () => {
       const res = await client.stringParameter(
-        "/lambda-ext-test-param/dummy-string"
+        "/lambda-ext-test-param/dummy-string",
       );
       expect(res).toBe("my-string-param-value");
     });
 
     test("Return the Extension response object, not just the value.", async () => {
       const res = await client.parameterResponse(
-        "/lambda-ext-test-param/dummy-string"
+        "/lambda-ext-test-param/dummy-string",
       );
 
       const isHappyResponse = ParameterHandler.isParameterResponse(res);
@@ -39,7 +39,7 @@ describe("Client returns the expected mock requests.", () => {
 
     test("stringListParameter returns an array of strings.", async () => {
       const res = await client.stringListParameter(
-        "/lambda-ext-test-param/dummy-string-list"
+        "/lambda-ext-test-param/dummy-string-list",
       );
       expect(Array.isArray(res)).toBeTruthy();
       expect(res?.every((el) => typeof el === "string")).toBe(true);
@@ -47,7 +47,7 @@ describe("Client returns the expected mock requests.", () => {
 
     test("secureString returns the decrypted value by default.", async () => {
       const res = await client.secureStringParameter(
-        "/lambda-ext-test-param/dummy-secure-string"
+        "/lambda-ext-test-param/dummy-secure-string",
       );
       expect(res).toMatch(/^my-secure-string-value.*/);
     });
@@ -58,7 +58,7 @@ describe("Client returns the expected mock requests.", () => {
         {
           version: 1, // N.B. including a version ensures key uniqueness, lets the MockRequester look up the right entry in the mock responses
           withDecryption: false,
-        }
+        },
       );
       expect(res?.length).toBeGreaterThan(200);
     });
@@ -92,7 +92,7 @@ describe("Client returns the expected mock requests.", () => {
         expect(res?.SecretString).toBe("an-insecure-string-secret-value");
         expect(res?.SecretBinary).toBe(null);
         expect(res?.VersionStages).toEqual(
-          expect.arrayContaining(["AWSCURRENT"])
+          expect.arrayContaining(["AWSCURRENT"]),
         );
       }
     });
@@ -103,7 +103,7 @@ describe("Client returns the expected mock requests.", () => {
       });
       expect(res instanceof Buffer).toBe(true);
       expect(res?.toString("utf-8")).toBe(
-        "a string secret value to be saved as binary"
+        "a string secret value to be saved as binary",
       );
     });
 
@@ -111,7 +111,7 @@ describe("Client returns the expected mock requests.", () => {
       expect(
         await client.stringSecret("dummy-string-secret", {
           versionStage: "DOESNOTEXIST",
-        })
+        }),
       ).toBe(null);
     });
   });

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -117,7 +117,7 @@ export class Client {
       props?.port ??
         process.env.PARAMETERS_SECRETS_EXTENSION_HTTP_PORT ??
         "2773",
-      10
+      10,
     );
 
     this.baseUrl = `http://localhost:${port}`;
@@ -127,7 +127,7 @@ export class Client {
     if (!token) {
       throw new Error(
         "Missing token.  Expected a AWS session token in AWS_SESSION_TOKEN." +
-          "\nEnsure the AWS-Parameters-and-Secrets-Lambda-Extension Layer is enabled on the Lambda."
+          "\nEnsure the AWS-Parameters-and-Secrets-Lambda-Extension Layer is enabled on the Lambda.",
       );
     }
 
@@ -140,7 +140,7 @@ export class Client {
    * Get the resource.
    */
   private async getResource<T extends ExtensionResponse>(
-    handler: Handler
+    handler: Handler,
   ): Promise<T | ErrorResponse> {
     const res = await this.requester.get(this.baseUrl + handler.path);
 
@@ -160,7 +160,7 @@ export class Client {
    */
   async stringParameter(
     parameterName: string,
-    options?: StringParameterOptions
+    options?: StringParameterOptions,
   ): Promise<string | null> {
     const response = await this.parameterResponse(parameterName, options);
 
@@ -169,7 +169,7 @@ export class Client {
 
     if (
       !["String", "StringList", "SecureString"].includes(
-        response.Parameter.Type
+        response.Parameter.Type,
       )
     ) {
       return null;
@@ -188,7 +188,7 @@ export class Client {
    */
   async stringListParameter(
     parameterName: string,
-    options?: StringListParameterOptions
+    options?: StringListParameterOptions,
   ): Promise<string[] | null> {
     const response = await this.parameterResponse(parameterName, options);
 
@@ -207,7 +207,7 @@ export class Client {
    */
   async secureStringParameter(
     parameterName: string,
-    options?: SecureStringParameterOptions
+    options?: SecureStringParameterOptions,
   ): Promise<string | null> {
     const response = await this.parameterResponse(parameterName, {
       withDecryption: true,
@@ -230,7 +230,7 @@ export class Client {
    */
   async stringSecretfromParameterStore(
     secretId: string,
-    options?: SecretFromParamStoreOptions
+    options?: SecretFromParamStoreOptions,
   ): Promise<string | null> {
     const response = await this.parameterResponse(secretId, {
       fromSecretsManager: true,
@@ -252,7 +252,7 @@ export class Client {
    */
   async binarySecretfromParameterStore(
     secretId: string,
-    options?: SecretFromParamStoreOptions
+    options?: SecretFromParamStoreOptions,
   ): Promise<Buffer | null> {
     const response = await this.parameterResponse(secretId, {
       fromSecretsManager: true,
@@ -279,7 +279,7 @@ export class Client {
    */
   async parameterResponse(
     parameterName: string,
-    options?: ParameterOptions
+    options?: ParameterOptions,
   ): Promise<ParameterResponse | ErrorResponse> {
     const handler = new ParameterHandler({
       parameterName,
@@ -310,7 +310,7 @@ export class Client {
    */
   async stringSecret(
     secretId: string,
-    options?: SecretOptions
+    options?: SecretOptions,
   ): Promise<string | null> {
     const response = await this.secretResponse(secretId, options);
 
@@ -329,7 +329,7 @@ export class Client {
    */
   async binarySecret(
     secretId: string,
-    options?: SecretOptions
+    options?: SecretOptions,
   ): Promise<Buffer | null> {
     const response = await this.secretResponse(secretId, options);
     // GetSecretValueCommandOutput: "The response parameter represents the binary data as a base64-encoded string.""
@@ -353,7 +353,7 @@ export class Client {
    */
   async secretResponse(
     secretId: string,
-    options?: SecretOptions
+    options?: SecretOptions,
   ): Promise<SecretResponse | ErrorResponse> {
     const handler = new SecretHandler({ secretId, ...options });
     return this.getResource(handler);

--- a/src/lib/handlers.test.ts
+++ b/src/lib/handlers.test.ts
@@ -4,14 +4,14 @@ describe("Parameter paths", () => {
   test("Parameter path rendered", () => {
     const handler = new ParameterHandler({ parameterName: "/cdk/temp" });
     expect(handler.path).toBe(
-      "/systemsmanager/parameters/get?name=%2Fcdk%2Ftemp"
+      "/systemsmanager/parameters/get?name=%2Fcdk%2Ftemp",
     );
   });
 
   test("No-slash Parameter path rendered", () => {
     const handler = new ParameterHandler({ parameterName: "no-forward-slash" });
     expect(handler.path).toBe(
-      "/systemsmanager/parameters/get?name=no-forward-slash"
+      "/systemsmanager/parameters/get?name=no-forward-slash",
     );
   });
 
@@ -21,7 +21,7 @@ describe("Parameter paths", () => {
       version: 2,
     });
     expect(handler.path).toBe(
-      "/systemsmanager/parameters/get?name=%2Fcdk%2Ftemp&version=2"
+      "/systemsmanager/parameters/get?name=%2Fcdk%2Ftemp&version=2",
     );
   });
 
@@ -31,7 +31,7 @@ describe("Parameter paths", () => {
       fromSecretsManager: true,
     });
     expect(handler.path).toBe(
-      "/systemsmanager/parameters/get?name=%2Faws%2Freference%2Fsecretsmanager%2Fmy-secret"
+      "/systemsmanager/parameters/get?name=%2Faws%2Freference%2Fsecretsmanager%2Fmy-secret",
     );
   });
 
@@ -41,7 +41,7 @@ describe("Parameter paths", () => {
       fromSecretsManager: true,
     });
     expect(handler.path).toBe(
-      "/systemsmanager/parameters/get?name=%2Faws%2Freference%2Fsecretsmanager%2Fmy-secret"
+      "/systemsmanager/parameters/get?name=%2Faws%2Freference%2Fsecretsmanager%2Fmy-secret",
     );
   });
 });
@@ -58,7 +58,7 @@ describe("Secret paths", () => {
       versionId: "a55ed8eb-0d14-4c5c-877c-0a94c63709ed",
     });
     expect(pr.path).toBe(
-      "/secretsmanager/get?secretId=james-bond&versionId=a55ed8eb-0d14-4c5c-877c-0a94c63709ed"
+      "/secretsmanager/get?secretId=james-bond&versionId=a55ed8eb-0d14-4c5c-877c-0a94c63709ed",
     );
   });
 
@@ -68,7 +68,7 @@ describe("Secret paths", () => {
       versionStage: "AWSPREVIOUS",
     });
     expect(pr.path).toBe(
-      "/secretsmanager/get?secretId=james-bond&versionStage=AWSPREVIOUS"
+      "/secretsmanager/get?secretId=james-bond&versionStage=AWSPREVIOUS",
     );
   });
 });

--- a/src/lib/handlers.ts
+++ b/src/lib/handlers.ts
@@ -74,7 +74,7 @@ export class ParameterHandler extends Handler {
    * @returns true if `response` is a ParameterResponse
    */
   static isParameterResponse(
-    response: ExtensionResponse
+    response: ExtensionResponse,
   ): response is ParameterResponse {
     return typeof response === "object" && "Parameter" in response;
   }
@@ -105,7 +105,7 @@ export class ParameterHandler extends Handler {
   get path(): string {
     const url = new URL(
       "/systemsmanager/parameters/get",
-      "http://not-used.dummy"
+      "http://not-used.dummy",
     );
 
     url.searchParams.append("name", this.parameterName);
@@ -157,7 +157,7 @@ export class SecretHandler extends Handler {
    * @returns true if `response` is a SecretResponse
    */
   static isSecretResponse(
-    response: ExtensionResponse
+    response: ExtensionResponse,
   ): response is SecretResponse {
     return typeof response === "object" && "SecretString" in response;
   }

--- a/src/lib/requester.ts
+++ b/src/lib/requester.ts
@@ -58,14 +58,14 @@ export class HttpResponse implements Response {
   static failureResponse(
     data: string,
     statusCode: number | string,
-    statusMessage: string
+    statusMessage: string,
   ): Response {
     return new HttpResponse(`${statusCode} ${statusMessage}: ${data}`, true);
   }
 
   private constructor(
     private data: string,
-    public isError: boolean = false
+    public isError: boolean = false,
   ) {}
 
   get text(): string | null {
@@ -126,15 +126,15 @@ export class HttpRequester implements Requester {
           : HttpResponse.failureResponse(
               data,
               res.statusCode ?? "<?>",
-              res.statusMessage ?? "<Unknown Status>"
+              res.statusMessage ?? "<Unknown Status>",
             );
       })
       .catch((err) =>
         HttpResponse.failureResponse(
           err,
           res.statusCode ?? "<?>",
-          "<Rejection>"
-        )
+          "<Rejection>",
+        ),
       );
   }
 }

--- a/src/mocks/MockRequester.mock.ts
+++ b/src/mocks/MockRequester.mock.ts
@@ -32,8 +32,8 @@ export class MockRequester implements Requester {
           HttpResponse.failureResponse(
             `Cannot find ${resource} in the test responses.`,
             0,
-            "<unknown>"
-          )
+            "<unknown>",
+          ),
         );
       }
 
@@ -43,8 +43,8 @@ export class MockRequester implements Requester {
             HttpResponse.failureResponse(
               testResponse.error.replace("400 Bad Request: ", ""), // test responses already have the statusCode and status Message
               400,
-              "Bad Request"
-            )
+              "Bad Request",
+            ),
           )
         : resolve(HttpResponse.successResponse(JSON.stringify(testResponse)));
     });


### PR DESCRIPTION
Apply the `trailingComma` `all`, setting, which became the default in Prettier v3.0.

Fixes: #20