### PR TITLE
fix: IDE global fetch warning

### DIFF
--- a/src/lib/requester.ts
+++ b/src/lib/requester.ts
@@ -1,3 +1,4 @@
+/*global fetch*/
 import http from "http";
 import https from "https";
 // https://stackoverflow.com/questions/71294230/how-can-i-use-native-fetch-with-node-in-typescript-node-v17-6

--- a/src/lib/requester.ts
+++ b/src/lib/requester.ts
@@ -1,4 +1,3 @@
-/*global fetch*/
 import http from "http";
 import https from "https";
 // https://stackoverflow.com/questions/71294230/how-can-i-use-native-fetch-with-node-in-typescript-node-v17-6
@@ -162,6 +161,7 @@ export class FetchRequester implements Requester {
     this.headers = headers;
   }
 
+  /*global fetch*/
   async get(url: string): Promise<Response> {
     try {
       const res = await fetch(url, { headers: this.headers });


### PR DESCRIPTION
Suppress the warning "fetch is not defined" in the Lambda IDE