### PR TITLE
fix: suppress eslint error in the console IDE

### DIFF
--- a/src/lib/requester.ts
+++ b/src/lib/requester.ts
@@ -74,8 +74,7 @@ export class HttpResponse implements Response {
     return this.isError ? null : this.data;
   }
 
-  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-  get json(): any {
+  get json() {
     try {
       if (this.isError) return null;
       return JSON.parse(this.data);


### PR DESCRIPTION
The Lambda console IDE shows an error due to an eslint-disable comment not removed by esbuild.   Fix by removing the comment and the explicit any.